### PR TITLE
Ensure correct folder and file permissions in deploy task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -68,7 +68,7 @@
                 "createfolders",
                 "chmodfolders"
             ],
-            "command": "rsync -azp --delete --rsh='ssh -p ${config:deckport} ${config:deckkey}' --exclude='.git/' --exclude='.github/' --exclude='.vscode/' --exclude='node_modules/' --exclude='src/' --exclude='*.log' --exclude='.gitignore' . deck@${config:deckip}:${config:deckdir}/homebrew/plugins/${workspaceFolderBasename}",
+            "command": "rsync -azp --delete --chmod=D0755,F0755 --rsh='ssh -p ${config:deckport} ${config:deckkey}' --exclude='.git/' --exclude='.github/' --exclude='.vscode/' --exclude='node_modules/' --exclude='src/' --exclude='*.log' --exclude='.gitignore' . deck@${config:deckip}:${config:deckdir}/homebrew/plugins/${workspaceFolderBasename}",
             "problemMatcher": []
         },
         {


### PR DESCRIPTION
The VS Code tasks only set permissions for a couple directories in the `chmodfolders` task. Any files & directories that are being synced to the Steamdeck via the `deploy` task retains its original permission set in the development environment.

I'm personally developing in an ArchLinux WSL2 Win 11 environment using VS Code and noticed that the files in my development environment had incorrect permissions which prevented the synced files in the Steamdeck from loading.

This PR ensures that the folders and files deployed has the correct permissions.