### PR TITLE
Add simple support for dependent python modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage
 # Dependency directory
 node_modules
 bower_components
+py_modules
 
 # Editors
 .idea

--- a/main.py
+++ b/main.py
@@ -1,3 +1,8 @@
+import os
+import sys
+# append py_modules to PYTHONPATH
+sys.path.append(os.path.dirname(os.path.realpath(__file__))+"/py_modules")
+
 import logging
 
 logging.basicConfig(filename="/tmp/template.log",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "description": "A template to quickly create decky plugins from scratch, based on TypeScript and webpack",
   "scripts": {
-    "pipinstall": "if [ -f requirements.txt ]; then\n\tpip install -U -r requirements.txt -t py_modules\nfi",
-    "build": "pnpm run pipinstall && shx rm -rf dist && rollup -c",
+    "pip_install": "if [ -f requirements.txt ]; then\n\tpip install -U -r requirements.txt -t py_modules\nfi",
+    "build_frontend": "shx rm -rf dist && rollup -c",
+    "build": "pnpm run pipinstall && pnpm run build_frontend",
     "watch": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "0.0.1",
   "description": "A template to quickly create decky plugins from scratch, based on TypeScript and webpack",
   "scripts": {
-    "pip_install": "if [ -f requirements.txt ]; then\n\tpip install -U -r requirements.txt -t py_modules\nfi",
-    "build_frontend": "shx rm -rf dist && rollup -c",
-    "build": "pnpm run pipinstall && pnpm run build_frontend",
+    "prepare": "if [ -f requirements.txt ]; then\n\tpip install -U -r requirements.txt -t py_modules\nfi",
+    "build": "shx rm -rf dist && rollup -c",
     "watch": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A template to quickly create decky plugins from scratch, based on TypeScript and webpack",
   "scripts": {
-    "prepare": "if [ -f requirements.txt ]; then\n\tpip install -U -r requirements.txt -t py_modules\nfi",
+    "prepare": "if [ -f requirements.txt ]; then\n\tpip3 install -U -r requirements.txt -t py_modules\nfi",
     "build": "shx rm -rf dist && rollup -c",
     "watch": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A template to quickly create decky plugins from scratch, based on TypeScript and webpack",
   "scripts": {
-    "prepare": "if [ -f requirements.txt ]; then\n\tpip3 install -U -r requirements.txt -t py_modules\nfi",
+    "prepare": "touch requirements.txt && pip3 install --upgrade -r requirements.txt -t py_modules",
     "build": "shx rm -rf dist && rollup -c",
     "watch": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "A template to quickly create decky plugins from scratch, based on TypeScript and webpack",
   "scripts": {
-    "build": "shx rm -rf dist && rollup -c",
+    "pipinstall": "if [ -f requirements.txt ]; then\n\tpip install -U -r requirements.txt -t py_modules\nfi",
+    "build": "pnpm run pipinstall && shx rm -rf dist && rollup -c",
     "watch": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- use `prepare` script in `package.json` to install python dependencies in a `py_modules` folder
- append `py_modules` to `PYTHONPATH` at the beginning of `main.py` to allow dependencies
