### PR TITLE
Replace NavigateToStore

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,8 +82,8 @@ const DeckyPluginRouterTest: VFC = () => {
   return (
     <div style={{ marginTop: "50px", color: "white" }}>
       Hello World!
-      <DialogButton onClick={() => Router.NavigateToStore()}>
-        Go to Store
+      <DialogButton onClick={() => Router.NavigateToLibraryTab()}>
+        Go to Library
       </DialogButton>
     </div>
   );


### PR DESCRIPTION
Router.NavigateToStore() got removed with

https://github.com/SteamDeckHomebrew/decky-frontend-lib/commit/f0379e5d19279863b571e66918bc9107efedb612
and the button did nothing. 

I replaced it with a navigation to the library because i`m not sure what the exact replacement for NavigateToStore is.