### PR TITLE
Add a 'restartloader' tasks to restart the python backend.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,6 +72,15 @@
             "problemMatcher": []
         },
         {
+            "label": "restartloader",
+            "detail": "Restart the plugin loader (to load updated python code)",
+            "type": "shell",
+            "group": "none",
+            "dependsOn": [],
+            "command": "ssh deck@${config:deckip} -p ${config:deckport} ${config:deckkey} 'echo '${config:deckpass}' | sudo -S systemctl restart plugin_loader'",
+            "problemMatcher": []
+        },
+        {
             "label": "chmodfolders",
             "detail": "chmods folders to prevent perms issues",
             "type": "shell",
@@ -98,6 +107,8 @@
             "dependsOn": [
                 "buildall",
                 "deployall"
+                // Uncomment this line if you'd like your python code reloaded after deployment (this will restart Steam)
+                // ,"restartloader"
             ],
             "problemMatcher": []
         }


### PR DESCRIPTION
This is useful for testing/developing the python code.

Request to reviewers: I also added this as the last subtask on allinone. Is there any downside to the workflow of devs developing/testing the JS code by whacking Steam this way? If so, I can revise to remove that automatic invocation.