### PR TITLE
Fix setup cli detection

### DIFF
--- a/.vscode/setup.sh
+++ b/.vscode/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 PNPM_INSTALLED="$(which pnpm)"
 DOCKER_INSTALLED="$(which docker)"
-CLI_INSTALLED="$(test -f $(pwd)/cli/decky | echo "$?")"
+CLI_INSTALLED="$(pwd)/cli/decky"
 
 # echo "$PNPM_INSTALLED"
 # echo "$DOCKER_INSTALLED"
@@ -34,7 +34,7 @@ if [[ "$DOCKER_INSTALLED" =~ "which" ]]; then
     echo "Docker is not currently installed, in order build plugins with a backend you will need to have Docker installed. Please install Docker via the preferred method for your distribution."
 fi
 
-if [[ "$CLI_INSTALLED" > "0" ]] || [[ "$CLI_INSTALLED" < "0" ]]; then
+if ! test -f "$CLI_INSTALLED"; then
     echo "The Decky CLI tool (binary file is just called "decky") is used to build your plugin as a zip file which you can then install on your Steam Deck to perform testing. We highly recommend you install it. Hitting enter now will run the script to install Decky CLI and extract it to a folder called cli in the current plugin directory. You can also type 'no' and hit enter to skip this but keep in mind you will not have a usable plugin without building it."
     read run_cli_script
     if [[ "$run_cli_script" =~ "n" ]]; then


### PR DESCRIPTION
For some reason, the previous setup shell script would always return `0` for the CLI installation check. I doubt it's because of my Linux install but these changes fix them for me.