### PR TITLE
Make `setup.sh` download the correct binaries.

### DIFF
--- a/.vscode/setup.sh
+++ b/.vscode/setup.sh
@@ -40,8 +40,28 @@ if ! test -f "$CLI_INSTALLED"; then
     if [[ "$run_cli_script" =~ "n" ]]; then
         echo "You have chosen to not install the Decky CLI tool to build your plugins. Please install this tool to build and test your plugin before submitting it to the Plugin Database."
     else
+
+        SYSTEM_ARCH="$(uname -a)"
+
         mkdir "$(pwd)"/cli
-        curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky"
+        if [[ "$SYSTEM_ARCH" =~ "x86_64" ]]; then
+
+            if [[ "$SYSTEM_ARCH" =~ "Linux" ]]; then
+                curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-linux-x86_64"
+            fi
+            
+            if [[ "$SYSTEM_ARCH" =~ "Darwin" ]]; then
+                curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-macOS-x86_64"
+            fi
+
+        else
+            echo "System Arch not found! The only supported systems are Linux x86_64 and Apple x86_64/ARM64, not $SYSTEM_ARCH"
+        fi
+
+        if [[ "$SYSTEM_ARCH" =~ "arm64" ]]; then
+            curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-macOS-aarch64"
+        fi
+        
         chmod +x "$(pwd)"/cli/decky
         echo "Decky CLI tool is now installed and you can build plugins into easy zip files using the "Build Zip" Task in vscodium."
     fi


### PR DESCRIPTION
`setup.sh` downloads non-existent binaries for Decky CLI, creating a file with the contents "Not Found". This puts a check for both the OS and arch so the right files are downloaded.