### PR TITLE
Fix: Missing dependency causing build failure on M series macs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@decky/rollup": "^1.0.1",
     "@decky/ui": "^4.7.2",
+    "@rollup/rollup-linux-x64-musl": "4.22.5",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@types/webpack": "^5.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@decky/ui':
         specifier: ^4.7.2
         version: 4.7.2
+      '@rollup/rollup-linux-x64-musl':
+        specifier: 4.22.5
+        version: 4.22.5
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
@@ -1055,8 +1058,7 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.22.5':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.22.5':
-    optional: true
+  '@rollup/rollup-linux-x64-musl@4.22.5': {}
 
   '@rollup/rollup-win32-arm64-msvc@4.22.5':
     optional: true


### PR DESCRIPTION
Added `@rollup/rollup-linux-x64-musl@4.22.5` to `package.json` to fix build errors on M series macs.

### Todo:
- [ ] Verify that the template still functions properly on linux.

### Other Quirks:
- Macbooks use a dated version of `rsync` that needs to be updated for the deploy tasks to function properly. 
  - This can be easily fixed by installing `rsync` via [brew.sh](https://formulae.brew.sh).
